### PR TITLE
Fix install command for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "8"
 install:
   - npm cache verify
-  - npm install
+  - npm install --no-package-lock
 cache:
   directories:
     - "$HOME/.npm"


### PR DESCRIPTION
"npm install" does not update package-lock.json to avoid unnecessary updating it when install process. Update "package-lock.json" with "lerna bootstrap".
