### PR TITLE
Remove @babel/polyfill from dependencies

### DIFF
--- a/examples/multi-device/package.json
+++ b/examples/multi-device/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "@hidoo/eslint-config": "^0.1.4",
@@ -44,6 +43,7 @@
     "babel-preset-power-assert": "^3.0.0",
     "browser-sync": "^2.26.7",
     "commander": "^2.19.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "eslint": "^6.1.0",
     "express": "^4.17.1",
@@ -55,6 +55,7 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {}

--- a/examples/multi-device/src/js/mocha.opts
+++ b/examples/multi-device/src/js/mocha.opts
@@ -1,5 +1,5 @@
 --require @babel/register
---require @babel/polyfill
+--require @core-js
 --require jsdom-global/register
 --recursive
 --ui bdd

--- a/examples/single-device/package.json
+++ b/examples/single-device/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "@hidoo/eslint-config": "^0.1.4",
@@ -44,6 +43,7 @@
     "babel-preset-power-assert": "^3.0.0",
     "browser-sync": "^2.26.7",
     "commander": "^2.19.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "eslint": "^6.1.0",
     "express": "^4.17.1",
@@ -55,6 +55,7 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {}

--- a/examples/single-device/src/js/mocha.opts
+++ b/examples/single-device/src/js/mocha.opts
@@ -1,5 +1,5 @@
 --require @babel/register
---require @babel/polyfill
+--require @core-js
 --require jsdom-global/register
 --recursive
 --ui bdd

--- a/examples/use-sass/package.json
+++ b/examples/use-sass/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "@hidoo/eslint-config": "^0.1.4",
@@ -44,6 +43,7 @@
     "babel-preset-power-assert": "^3.0.0",
     "browser-sync": "^2.26.7",
     "commander": "^2.19.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "eslint": "^6.1.0",
     "express": "^4.17.1",
@@ -55,6 +55,7 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {}

--- a/examples/use-sass/src/js/mocha.opts
+++ b/examples/use-sass/src/js/mocha.opts
@@ -1,5 +1,5 @@
 --require @babel/register
---require @babel/polyfill
+--require @core-js
 --require jsdom-global/register
 --recursive
 --ui bdd

--- a/packages/gulp-project-generator/src/generatePackageJson.js
+++ b/packages/gulp-project-generator/src/generatePackageJson.js
@@ -79,12 +79,13 @@ export default async function generatePackageJson(name = '', dest = '', options 
   }
   if (options.js) {
     devDependencies.push(
-      {name: '@babel/polyfill', version: '^7.4.4'},
       {name: 'babel-preset-power-assert', version: '^3.0.0'},
+      {name: 'core-js', version: '^2.6.9'},
       {name: 'jsdom', version: '^15.1.1'},
       {name: 'jsdom-global', version: '^3.0.2'},
       {name: 'mocha', version: '^6.2.0'},
-      {name: 'power-assert', version: '^1.6.1'}
+      {name: 'power-assert', version: '^1.6.1'},
+      {name: 'regenerator-runtime', version: '^0.13.3'}
     );
     scripts.push(
       {name: 'test:unit', command: 'cross-env NODE_ENV=test mocha ./src/js/**/*.test.js --opts ./src/js/mocha.opts'}

--- a/packages/gulp-project-generator/template/src/js/mocha.opts
+++ b/packages/gulp-project-generator/template/src/js/mocha.opts
@@ -1,5 +1,5 @@
 --require @babel/register
---require @babel/polyfill
+--require core-js
 --require jsdom-global/register
 --recursive
 --ui bdd

--- a/packages/gulp-project-generator/test/fixtures/expected/package-conventional-commits.json
+++ b/packages/gulp-project-generator/test/fixtures/expected/package-conventional-commits.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "@commitlint/cli": "^8.1.0",
@@ -50,6 +49,7 @@
     "browser-sync": "^2.26.7",
     "commander": "^2.19.0",
     "conventional-changelog-cli": "^2.0.5",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "eslint": "^6.1.0",
     "express": "^4.17.1",
@@ -61,6 +61,7 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {}

--- a/packages/gulp-project-generator/test/fixtures/expected/package.json
+++ b/packages/gulp-project-generator/test/fixtures/expected/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "@hidoo/eslint-config": "^0.1.4",
@@ -44,6 +43,7 @@
     "babel-preset-power-assert": "^3.0.0",
     "browser-sync": "^2.26.7",
     "commander": "^2.19.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "eslint": "^6.1.0",
     "express": "^4.17.1",
@@ -55,6 +55,7 @@
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {}

--- a/packages/gulp-task-build-js-browserify/package.json
+++ b/packages/gulp-task-build-js-browserify/package.json
@@ -28,16 +28,17 @@
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "babel-preset-power-assert": "^3.0.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "documentation": "^12.0.2",
     "gulp": "^4.0.2",
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {
@@ -55,9 +56,6 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
-    "@babel/preset-env": "^7.5.0",
     "gulp": "^4.0.2"
   }
 }

--- a/packages/gulp-task-build-js-rollup/package.json
+++ b/packages/gulp-task-build-js-rollup/package.json
@@ -28,16 +28,17 @@
   "devDependencies": {
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.5.0",
     "@babel/register": "^7.4.4",
     "babel-preset-power-assert": "^3.0.0",
+    "core-js": "^2.6.9",
     "cross-env": "^5.2.0",
     "documentation": "^12.0.2",
     "gulp": "^4.0.2",
     "mocha": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
+    "regenerator-runtime": "^0.13.3",
     "rimraf": "^2.6.3"
   },
   "dependencies": {
@@ -59,9 +60,6 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.5.0",
-    "@babel/polyfill": "^7.4.4",
-    "@babel/preset-env": "^7.5.0",
     "gulp": "^4.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,7 +854,7 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7.0.0", "@babel/polyfill@^7.4.4":
+"@babel/polyfill@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
   integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
@@ -4275,7 +4275,7 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5, core-js@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -12072,7 +12072,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2:
+regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==


### PR DESCRIPTION
Fix to use instead core-js and regenerator-runtime.

> 🚨 As of Babel 7.4.0, this package has been deprecated in favor of directly including core-js/stable (to polyfill ECMAScript features) and regenerator-runtime/runtime (needed to use transpiled generator functions):
> https://babeljs.io/docs/en/next/babel-polyfill.html